### PR TITLE
Math comparison tool

### DIFF
--- a/cte-collation-poc/extractmath.py
+++ b/cte-collation-poc/extractmath.py
@@ -23,8 +23,7 @@ def main(html_in, html_out=sys.stdout):
 
     math = math_xpath(body)
 
-    for c in body.iterchildren():
-        body.remove(c)
+    body.clear()
 
     for m in math:
         body.append(m)

--- a/cte-collation-poc/extractmath.py
+++ b/cte-collation-poc/extractmath.py
@@ -26,6 +26,7 @@ def main(html_in, html_out=sys.stdout):
     body.clear()
 
     for m in math:
+        m.tail = None
         body.append(m)
 
     print(etree.tostring(html), file=html_out)

--- a/cte-collation-poc/extractmath.py
+++ b/cte-collation-poc/extractmath.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import sys
+import argparse
+
+from lxml import etree
+
+NS = {'x': 'http://www.w3.org/1999/xhtml',
+      'mml':'http://www.w3.org/1998/Math/MathML'}
+
+body_xpath = etree.XPath('//x:body', namespaces=NS)
+
+math_xpath = etree.XPath("//mml:math", namespaces=NS)
+
+
+def main(html_in, html_out=sys.stdout):
+    """Extract math nodes from book html file"""
+
+    html = etree.parse(html_in)
+
+    body = body_xpath(html)[0]
+
+    math = math_xpath(body)
+
+    for c in body.iterchildren():
+        body.remove(c)
+
+    for m in math:
+        body.append(m)
+
+    print(etree.tostring(html), file=html_out)
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description="Extract only math nodes from book html file")
+    parser.add_argument("html_in",
+                        type=argparse.FileType('r'),
+                        help="assembled fullbook HTML file")
+    parser.add_argument("html_out", nargs="?",
+                        type=argparse.FileType('w'),
+                        help="math-only HTML file output (default stdout)",
+                        default=sys.stdout)
+    args = parser.parse_args()
+    main(args.html_in, args.html_out)

--- a/cte-collation-poc/fullbook.py
+++ b/cte-collation-poc/fullbook.py
@@ -10,8 +10,9 @@ from lxml import etree
 ARCHIVEJS = 'http://archive.cnx.org/contents/{}.json'
 ARCHIVEHTML = 'http://archive.cnx.org/contents/{}.html'
 NS = {'x': 'http://www.w3.org/1999/xhtml'}
-SCRIPT_WRAPPER = """<script src="https://cdn.mathjax.org/mathjax/{mathjax_version}-latest/unpacked/MathJax.js?config=TeX-MML-AM_CHTML"> </script>
-"""
+SCRIPT_WRAPPER = '<script '\
+                 'src="https://cdn.mathjax.org/mathjax/{mathjax_version}/'\
+                 'unpacked/MathJax.js?config=TeX-MML-AM_CHTML"> </script>'
 HTMLWRAPPER = """<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <title>{title}</title>
@@ -38,8 +39,12 @@ def main(code, html_out=sys.stdout, mathjax_version=None):
 
     res = requests.get(ARCHIVEJS.format(code))
     b_json = res.json()
-    script_tag = SCRIPT_WRAPPER.format(mathjax_version=mathjax_version) if mathjax_version else ''
-    html = etree.fromstring(HTMLWRAPPER.format(title=b_json['title'], script_tag=script_tag))
+    if mathjax_version:
+        script_tag = SCRIPT_WRAPPER.format(mathjax_version=mathjax_version)
+    else:
+        script_tag = ''
+    html = etree.fromstring(HTMLWRAPPER.format(title=b_json['title'],
+                            script_tag=script_tag))
     book_elem = etree.SubElement(html, 'body', attrib={'data-type': 'book'})
     title_elem = etree.SubElement(book_elem, 'div',
                                   attrib={'data-type': 'document-title'})
@@ -121,9 +126,9 @@ if __name__ == '__main__':
                         type=argparse.FileType('w'),
                         help="assembled HTML file output (default stdout)",
                         default=sys.stdout)
-    parser.add_argument("mathjax_version", nargs="?",
-                        help="MathJax version",
-                        default=None)
+    parser.add_argument('-m', "--mathjax_version", const="latest",
+                        metavar="mathjax_version", nargs="?",
+                        help="Add script tag to use MathJax of given version")
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='Send debugging info to stderr')
     parser.add_argument('-s', '--subset-chapters', dest='numchapters',
@@ -132,4 +137,8 @@ if __name__ == '__main__':
                         "(default 2 chapters plus extras)")
     args = parser.parse_args()
     verbose = args.verbose
-    main(args.bookid, args.html_out, args.mathjax_version)
+    mathjax_version = args.mathjax_version
+    if mathjax_version:
+        if not mathjax_version.endswith('latest'):
+            mathjax_version += '-latest'
+    main(args.bookid, args.html_out, mathjax_version)

--- a/cte-collation-poc/fullbook_mathonly.py
+++ b/cte-collation-poc/fullbook_mathonly.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+import sys
+import argparse
+import tempfile
+
+import fullbook
+import extractmath
+
+
+def main(code, mathjax_version=None, html_out=sys.stdout):
+    """Generate book HTML with math only."""
+    tmp = tempfile.TemporaryFile()
+    fullbook.main(code, tmp, mathjax_version)
+    tmp.seek(0, 0)
+    extractmath.main(tmp, html_out)
+    tmp.close()
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description="Assemble complete book "
+                                                 "as single HTML file")
+    parser.add_argument("bookid", help="Identifier of book: "
+                        "<uuid|shortId>[@ver]")
+    parser.add_argument("mathjax_version", nargs="?",
+                        help="MathJax version",
+                        default=None)
+    parser.add_argument("html_out", nargs="?",
+                        type=argparse.FileType('w'),
+                        help="assembled math-only HTML file output (default stdout)",
+                        default=sys.stdout)
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help='Send debugging info to stderr')
+    parser.add_argument('-s', '--subset-chapters', dest='numchapters',
+                        type=int, const=2, nargs='?', metavar='num_chapters',
+                        help="Create subset of complete book "
+                        "(default 2 chapters plus extras)")
+    args = parser.parse_args()
+    fullbook.verbose = args.verbose
+    fullbook.args = args
+    main(args.bookid, args.mathjax_version, args.html_out)

--- a/cte-collation-poc/poc-2.css
+++ b/cte-collation-poc/poc-2.css
@@ -1,0 +1,23 @@
+section[data-element-type='problems-exercises'] {
+  move-to: probs-123;
+}
+div[data-type='exercise'] > div[data-type='solution'] {
+  move-to: sol-234;
+}
+dl.definition {
+  copy-to: defs-345;
+}
+body div[data-type=chapter]::div {
+  class: eoc-exercises;
+  content: pending(probs-123);
+}
+body::div {
+  class: eob-solutions;
+  content: pending(sol-234);
+  group-by: div[data-type=chapter];
+}
+body::div {
+  class: eob-glossary;
+  content: pending(defs-345);
+  sort-by: dl > dt;
+}


### PR DESCRIPTION
- Added optional mathjax_version as the last param of fullbook.py (will insert a mathjax script tag for that version)
- Fullbook title is now a link to archive that also shows the uuid and version on the tooltip
- Added extractmath.py to extract all the math from the fullbook output (preserves the book title)
- Added fullbook_mathonly.py to do both steps together