### PR TITLE
TOC, document-title fixes/re-formatting

### DIFF
--- a/books/rulesets/common/collations.less
+++ b/books/rulesets/common/collations.less
@@ -74,13 +74,19 @@ body {
     }
   }
 .eob {
-    &.index {
-      .metadata("Index");
-      &::before {
-        pass: @pass-52-index-title;
-        container: h1;
-        data-type: document-title;
-        content: "Index";
+  &.index {
+    .metadata("Index");
+    &::before {
+      pass: @pass-52-index-title;
+      container: span;
+      content: "Index";
+      move-to: titleSpan;
+    }
+    &::before {
+      pass: @pass-52-index-title;
+      container: div;
+      data-type: document-title;
+      content: pending(titleSpan);
     }
   }
 }
@@ -201,7 +207,7 @@ body {
 }
 
 //Wrap all non-generated title content within a span before numbering
-[data-type="document-title"] {
+:not([data-type="metadata"]) > [data-type="document-title"] {
   content: none;
   &::after {
     content: content();

--- a/books/rulesets/common/collations.less
+++ b/books/rulesets/common/collations.less
@@ -167,17 +167,32 @@ body {
 .metadata(@title) {
     pass: @pass-75-metadata;
     content: nodes(bookMetadata) content();
-    [data-type="metadata"] {
-      [data-type="document-title"] {
-        pass: @pass-76-meta-title;
+  [data-type="metadata"] {
+    [data-type="document-title"] {
+      pass: @pass-76-meta-title;
       content: @title;
     }
   }
 }
 
+// div[data-type="document-title"] {
+//   content: "";
+//   &::after {
+//     content: content();
+//     container: span;
+//     move-to: h-title;
+//   }
+//   &::after {
+//     content: pending(h-title);
+//     container: h1;
+//   }
+// }
+
 [data-type="document-title"] {
   content: "";
+  pass: 66;
   &::after {
+    pass: 66;
     content: content();
     container: span;
   }

--- a/books/rulesets/common/collations.less
+++ b/books/rulesets/common/collations.less
@@ -174,6 +174,15 @@ body {
     }
   }
 }
+
+[data-type="document-title"] {
+  content: "";
+  &::after {
+    content: content();
+    container: span;
+  }
+}
+
 //todo
 // .feature(@name, @title, @nameTitle(@title,  @suffix) ) {
 //     section.references {

--- a/books/rulesets/common/collations.less
+++ b/books/rulesets/common/collations.less
@@ -125,10 +125,15 @@ body {
     }
   }
   &::before {
+    container: span;
+    content: @titleContent;
+    move-to: titleSpan;
+  }
+  &::before {
     container: @titleContainer;
     class: summary-title;
     data-type: document-title;
-    content: @titleContent;
+    content: pending(titleSpan);
     move-to: summaryTitle;
   }
   &::after {
@@ -149,10 +154,15 @@ body {
      }
   }
   &::before {
+    container: span;
+    content: @title;
+    move-to: titleSpan;
+  }
+  &::before {
     container: h1;
     class: sectionGlossary;
     data-type: document-title;
-    content: @title;
+    content: pending(titleSpan);
     move-to: sectionGlossary;
   }
   &::after {
@@ -165,8 +175,8 @@ body {
 
 //metadata
 .metadata(@title) {
-    pass: @pass-75-metadata;
-    content: nodes(bookMetadata) content();
+  pass: @pass-75-metadata;
+  content: nodes(bookMetadata) content();
   [data-type="metadata"] {
     [data-type="document-title"] {
       pass: @pass-76-meta-title;
@@ -175,24 +185,25 @@ body {
   }
 }
 
-// div[data-type="document-title"] {
-//   content: "";
-//   &::after {
-//     content: content();
-//     container: span;
-//     move-to: h-title;
-//   }
-//   &::after {
-//     content: pending(h-title);
-//     container: h1;
-//   }
-// }
+.doc-title (@title) {
+  &::before {
+    container: span;
+    pass: @pass-30-title;
+    content: @title;
+    move-to: titleSpan;
+  }
+  &::before {
+    pass: @pass-30-title;
+    container: div;
+    data-type: document-title;
+    content: pending(titleSpan);
+  }
+}
 
+//Wrap all non-generated title content within a span before numbering
 [data-type="document-title"] {
-  content: "";
-  pass: 66;
+  content: none;
   &::after {
-    pass: 66;
     content: content();
     container: span;
   }

--- a/books/rulesets/common/collations.less
+++ b/books/rulesets/common/collations.less
@@ -159,7 +159,7 @@ body {
     move-to: titleSpan;
   }
   &::before {
-    container: h1;
+    container: div;
     class: sectionGlossary;
     data-type: document-title;
     content: pending(titleSpan);

--- a/books/rulesets/common/mixins.less
+++ b/books/rulesets/common/mixins.less
@@ -1,5 +1,3 @@
-@pass-10-numbering: 10; /*Number chapters and static sections*/
-
 @pass-20-numbering-eoc: 20; /*Number solutions/EOC content*/
 
 @pass-25-solutions: 25; /*Assign exercise solutions to migrate to their own container*/
@@ -13,6 +11,7 @@
 @pass-60-toc: 60; /*Create everything associated with the toc*/
 
 @pass-65-toc-nav: 65; /*Create toc nav*/
+@pass-66-nav-unwrap: 66; /*Unwrap span elements copied from doc-titles*/
 
 @pass-75-metadata: 75; /*Add metadata to all locations*/
 @pass-76-meta-title: 76; /*Add title to metatdata sections*/

--- a/books/rulesets/common/toc.less
+++ b/books/rulesets/common/toc.less
@@ -143,14 +143,15 @@ nav#toc {
 nav#toc > ol {
   li {
     > a {
-      > h1 > span, > div > span{
-        pass: 68;
+      > h1 > span,
+      > div > span {
+        pass: @pass-66-nav-unwrap;
         move-to: title-spans;
       }
-      pass: 67;
+      pass: @pass-66-nav-unwrap;
       move-to:trash;
       &::outside {
-        pass: 67;
+        pass: @pass-66-nav-unwrap;
         content: pending(title-spans);
         container: a;
         attr-href: "#";

--- a/books/rulesets/common/toc.less
+++ b/books/rulesets/common/toc.less
@@ -4,14 +4,14 @@ body {
     string-set: page-id attr(id);
     // > div[data-type="metadata"] {
       > [data-type='document-title'] {
-          string-set: pageTitle content();
+          node-set: pageTitle;
           pass: @pass-60-toc;
           //copy-to: page-title;
       }
     // }
     &::after {
       pass: @pass-60-toc;
-      content: string(pageTitle);
+      content: nodes(pageTitle);
       attr-href: "#" string(page-id);
       container: a;
       move-to: page-link;
@@ -25,13 +25,13 @@ body {
   }
   > div[data-type='chapter'] {
       > h1[data-type='document-title'] {
-          string-set: chapterTitle content();
+          node-set: chapterTitle;
           pass: @pass-60-toc;
         //copy-to: eoc-toc;
       }
       &::after{
         pass: @pass-60-toc;
-        content: string(chapterTitle);
+        content: nodes(chapterTitle);
         attr-href: "#" string(page-id);
         container: a;
         move-to: eoc-toc;
@@ -42,12 +42,12 @@ body {
       //> div[data-type="metadata"] {
         > [data-type='document-title']{
         pass: @pass-60-toc;
-        string-set: PageTitle content();
+        node-set: PageTitle;
         //copy-to: page-title;
         }
         &::after {
           pass: @pass-60-toc;
-          content: string(PageTitle);
+          content: nodes(PageTitle);
           attr-href: "#" string(page-id);
           container: a;
           move-to: page-link;
@@ -139,3 +139,19 @@ nav#toc {
     container: ol;
   }
 }
+
+nav#toc > ol > li {
+  >a {
+    >h1>span{
+    pass: 66;
+    move-to: title-spans;
+    }
+    &::after {
+      pass: 66;
+      content: pending(title-spans);
+      container: a;
+      attr-href: "#";
+    }
+  }
+}
+

--- a/books/rulesets/common/toc.less
+++ b/books/rulesets/common/toc.less
@@ -144,12 +144,12 @@ nav#toc > ol {
   li {
     > a {
       > h1 > span, > div > span{
-        pass: 67;
+        pass: 68;
         move-to: title-spans;
       }
       //Purposely place an <a> inside and <a> to break the browser and have one appear after the other rather than inside
       &::after {
-        pass: 67;
+        pass: 68;
         content: pending(title-spans);
         container: a;
         attr-href: "#";

--- a/books/rulesets/common/toc.less
+++ b/books/rulesets/common/toc.less
@@ -140,17 +140,20 @@ nav#toc {
   }
 }
 
-nav#toc > ol > li {
-  >a {
-    >h1>span{
-    pass: 66;
-    move-to: title-spans;
-    }
-    &::after {
-      pass: 66;
-      content: pending(title-spans);
-      container: a;
-      attr-href: "#";
+nav#toc > ol {
+  li {
+    > a {
+      > h1 > span, > div > span{
+        pass: 67;
+        move-to: title-spans;
+      }
+      //Purposely place an <a> inside and <a> to break the browser and have one appear after the other rather than inside
+      &::after {
+        pass: 67;
+        content: pending(title-spans);
+        container: a;
+        attr-href: "#";
+      }
     }
   }
 }

--- a/books/rulesets/output/statistics.css
+++ b/books/rulesets/output/statistics.css
@@ -1,4 +1,3 @@
-/*Number chapters and static sections*/
 /*Number solutions/EOC content*/
 /*Assign exercise solutions to migrate to their own container*/
 /*Title existing EOC/EOB containers*/
@@ -6,6 +5,7 @@
 /*Create separate section in index for symbols*/
 /*Create everything associated with the toc*/
 /*Create toc nav*/
+/*Unwrap span elements copied from doc-titles*/
 /*Add metadata to all locations*/
 /*Add title to metatdata sections*/
 /**/
@@ -463,11 +463,9 @@ body::after {
   content: clear(trash);
 }
 [data-type="document-title"] {
-  content: "";
-  pass: 66;
+  content: none;
 }
 [data-type="document-title"]::after {
-  pass: 66;
   content: content();
   container: span;
 }
@@ -602,13 +600,17 @@ nav#toc::after {
   content: pending(eob-toc);
   container: ol;
 }
+nav#toc > ol li > a {
+  pass: 66;
+  move-to: trash;
+}
 nav#toc > ol li > a > h1 > span,
 nav#toc > ol li > a > div > span {
-  pass: 67;
+  pass: 66;
   move-to: title-spans;
 }
-nav#toc > ol li > a::after {
-  pass: 67;
+nav#toc > ol li > a::outside {
+  pass: 66;
   content: pending(title-spans);
   container: a;
   attr-href: "#";
@@ -624,10 +626,15 @@ div[data-type='chapter'] div[data-type="glossary"] dl.definition {
   move-to: eoc-key-terms;
 }
 div[data-type='chapter']::before {
+  container: span;
+  content: "Key Terms";
+  move-to: titleSpan;
+}
+div[data-type='chapter']::before {
   container: h1;
   class: sectionGlossary;
   data-type: document-title;
-  content: "Key Terms";
+  content: pending(titleSpan);
   move-to: sectionGlossary;
 }
 div[data-type='chapter']::after {
@@ -648,10 +655,15 @@ div[data-type='chapter'] section.summary::after {
   move-to: eoc-summaries;
 }
 div[data-type='chapter']::before {
-  container: h1;
+  container: span;
+  content: "Chapter Review";
+  move-to: titleSpan;
+}
+div[data-type='chapter']::before {
+  container: div;
   class: summary-title;
   data-type: document-title;
-  content: "Chapter Review";
+  content: pending(titleSpan);
   move-to: summaryTitle;
 }
 div[data-type='chapter']::after {
@@ -776,10 +788,16 @@ div[data-type='chapter'] .eoc.formula-review-container [data-type="metadata"] [d
   content: "Formula Review";
 }
 div[data-type='chapter'] .eoc.formula-review-container::before {
-  container: h1;
+  container: span;
   pass: 30;
-  data-type: document-title;
   content: "Formula Review";
+  move-to: titleSpan;
+}
+div[data-type='chapter'] .eoc.formula-review-container::before {
+  pass: 30;
+  container: div;
+  data-type: document-title;
+  content: pending(titleSpan);
 }
 div[data-type='chapter'] .eoc.practice-container {
   pass: 75;
@@ -790,10 +808,16 @@ div[data-type='chapter'] .eoc.practice-container [data-type="metadata"] [data-ty
   content: "Practice";
 }
 div[data-type='chapter'] .eoc.practice-container::before {
-  container: h1;
+  container: span;
   pass: 30;
-  data-type: document-title;
   content: "Practice";
+  move-to: titleSpan;
+}
+div[data-type='chapter'] .eoc.practice-container::before {
+  pass: 30;
+  container: div;
+  data-type: document-title;
+  content: pending(titleSpan);
 }
 div[data-type='chapter'] .eoc.free-response-container {
   pass: 75;
@@ -804,10 +828,16 @@ div[data-type='chapter'] .eoc.free-response-container [data-type="metadata"] [da
   content: "Homework";
 }
 div[data-type='chapter'] .eoc.free-response-container::before {
-  container: h1;
+  container: span;
   pass: 30;
-  data-type: document-title;
   content: "Homework";
+  move-to: titleSpan;
+}
+div[data-type='chapter'] .eoc.free-response-container::before {
+  pass: 30;
+  container: div;
+  data-type: document-title;
+  content: pending(titleSpan);
 }
 div[data-type='chapter'] .eoc.bring-together-exercises-container {
   pass: 75;
@@ -818,10 +848,16 @@ div[data-type='chapter'] .eoc.bring-together-exercises-container [data-type="met
   content: "Bringing It Together: Practice";
 }
 div[data-type='chapter'] .eoc.bring-together-exercises-container::before {
-  container: h1;
+  container: span;
   pass: 30;
-  data-type: document-title;
   content: "Bringing It Together: Practice";
+  move-to: titleSpan;
+}
+div[data-type='chapter'] .eoc.bring-together-exercises-container::before {
+  pass: 30;
+  container: div;
+  data-type: document-title;
+  content: pending(titleSpan);
 }
 div[data-type='chapter'] .eoc.bring-together-homework-container {
   pass: 75;
@@ -829,13 +865,19 @@ div[data-type='chapter'] .eoc.bring-together-homework-container {
 }
 div[data-type='chapter'] .eoc.bring-together-homework-container [data-type="metadata"] [data-type="document-title"] {
   pass: 76;
-  content: "Bringing It Together Homework";
+  content: "Bringing It Together: Homework";
 }
 div[data-type='chapter'] .eoc.bring-together-homework-container::before {
-  container: h1;
+  container: span;
   pass: 30;
-  data-type: document-title;
   content: "Bringing It Together: Homework";
+  move-to: titleSpan;
+}
+div[data-type='chapter'] .eoc.bring-together-homework-container::before {
+  pass: 30;
+  container: div;
+  data-type: document-title;
+  content: pending(titleSpan);
 }
 div[data-type='chapter'] .eoc.references-container {
   pass: 75;
@@ -846,10 +888,16 @@ div[data-type='chapter'] .eoc.references-container [data-type="metadata"] [data-
   content: "References";
 }
 div[data-type='chapter'] .eoc.references-container::before {
-  container: h1;
+  container: span;
   pass: 30;
-  data-type: document-title;
   content: "References";
+  move-to: titleSpan;
+}
+div[data-type='chapter'] .eoc.references-container::before {
+  pass: 30;
+  container: div;
+  data-type: document-title;
+  content: pending(titleSpan);
 }
 div[data-type='chapter'] .eoc.solutions-container {
   pass: 75;
@@ -860,8 +908,14 @@ div[data-type='chapter'] .eoc.solutions-container [data-type="metadata"] [data-t
   content: "Solutions";
 }
 div[data-type='chapter'] .eoc.solutions-container::before {
-  container: h1;
+  container: span;
   pass: 30;
-  data-type: document-title;
   content: "Solutions";
+  move-to: titleSpan;
+}
+div[data-type='chapter'] .eoc.solutions-container::before {
+  pass: 30;
+  container: div;
+  data-type: document-title;
+  content: pending(titleSpan);
 }

--- a/books/rulesets/output/statistics.css
+++ b/books/rulesets/output/statistics.css
@@ -462,6 +462,13 @@ body::after {
   pass: 100;
   content: clear(trash);
 }
+[data-type="document-title"] {
+  content: "";
+}
+[data-type="document-title"]::after {
+  content: content();
+  container: span;
+}
 body > div[data-type="page"],
 body > div[data-type="composite-page"] {
   pass: 60;
@@ -469,13 +476,13 @@ body > div[data-type="composite-page"] {
 }
 body > div[data-type="page"] > [data-type='document-title'],
 body > div[data-type="composite-page"] > [data-type='document-title'] {
-  string-set: pageTitle content();
+  node-set: pageTitle;
   pass: 60;
 }
 body > div[data-type="page"]::after,
 body > div[data-type="composite-page"]::after {
   pass: 60;
-  content: string(pageTitle);
+  content: nodes(pageTitle);
   attr-href: "#" string(page-id);
   container: a;
   move-to: page-link;
@@ -488,12 +495,12 @@ body > div[data-type="composite-page"]::after {
   container: li;
 }
 body > div[data-type='chapter'] > h1[data-type='document-title'] {
-  string-set: chapterTitle content();
+  node-set: chapterTitle;
   pass: 60;
 }
 body > div[data-type='chapter']::after {
   pass: 60;
-  content: string(chapterTitle);
+  content: nodes(chapterTitle);
   attr-href: "#" string(page-id);
   container: a;
   move-to: eoc-toc;
@@ -506,12 +513,12 @@ body > div[data-type='chapter'] > div[data-type="composite-page"] {
 body > div[data-type='chapter'] > div[data-type="page"] > [data-type='document-title'],
 body > div[data-type='chapter'] > div[data-type="composite-page"] > [data-type='document-title'] {
   pass: 60;
-  string-set: PageTitle content();
+  node-set: PageTitle;
 }
 body > div[data-type='chapter'] > div[data-type="page"]::after,
 body > div[data-type='chapter'] > div[data-type="composite-page"]::after {
   pass: 60;
-  content: string(PageTitle);
+  content: nodes(PageTitle);
   attr-href: "#" string(page-id);
   container: a;
   move-to: page-link;
@@ -592,6 +599,16 @@ nav#toc::after {
   pass: 65;
   content: pending(eob-toc);
   container: ol;
+}
+nav#toc > ol > li > a > h1 > span {
+  pass: 66;
+  move-to: title-spans;
+}
+nav#toc > ol > li > a::after {
+  pass: 66;
+  content: pending(title-spans);
+  container: a;
+  attr-href: "#";
 }
 body::after {
   pass: default;

--- a/books/rulesets/output/statistics.css
+++ b/books/rulesets/output/statistics.css
@@ -464,8 +464,10 @@ body::after {
 }
 [data-type="document-title"] {
   content: "";
+  pass: 66;
 }
 [data-type="document-title"]::after {
+  pass: 66;
   content: content();
   container: span;
 }
@@ -600,12 +602,13 @@ nav#toc::after {
   content: pending(eob-toc);
   container: ol;
 }
-nav#toc > ol > li > a > h1 > span {
-  pass: 66;
+nav#toc > ol li > a > h1 > span,
+nav#toc > ol li > a > div > span {
+  pass: 67;
   move-to: title-spans;
 }
-nav#toc > ol > li > a::after {
-  pass: 66;
+nav#toc > ol li > a::after {
+  pass: 67;
   content: pending(title-spans);
   container: a;
   attr-href: "#";

--- a/books/rulesets/output/statistics.css
+++ b/books/rulesets/output/statistics.css
@@ -631,7 +631,7 @@ div[data-type='chapter']::before {
   move-to: titleSpan;
 }
 div[data-type='chapter']::before {
-  container: h1;
+  container: div;
   class: sectionGlossary;
   data-type: document-title;
   content: pending(titleSpan);

--- a/books/rulesets/output/statistics.css
+++ b/books/rulesets/output/statistics.css
@@ -443,9 +443,15 @@ body .eob.index [data-type="metadata"] [data-type="document-title"] {
 }
 body .eob.index::before {
   pass: 52;
-  container: h1;
-  data-type: document-title;
+  container: span;
   content: "Index";
+  move-to: titleSpan;
+}
+body .eob.index::before {
+  pass: 52;
+  container: div;
+  data-type: document-title;
+  content: pending(titleSpan);
 }
 body::after {
   pass: 50;
@@ -462,10 +468,10 @@ body::after {
   pass: 100;
   content: clear(trash);
 }
-[data-type="document-title"] {
+:not([data-type="metadata"]) > [data-type="document-title"] {
   content: none;
 }
-[data-type="document-title"]::after {
+:not([data-type="metadata"]) > [data-type="document-title"]::after {
   content: content();
   container: span;
 }

--- a/books/rulesets/statistics.less
+++ b/books/rulesets/statistics.less
@@ -15,6 +15,7 @@
 body {
   //Clear the trash after certain passes
   &::after {
+    //get rid of try-it
     pass: default;
     content: clear(trash);
   }
@@ -30,7 +31,7 @@ div[data-type='chapter'] {
 div[data-type='chapter'] {
   .glossary("Key Terms");
 
-  .summary(summary, ~'.', h1, "Chapter Review");
+  .summary(summary, ~'.', div, "Chapter Review");
 
   section.formula-review {
     move-to: eoc-formula-review;
@@ -155,69 +156,33 @@ div[data-type='chapter'] {
     pass: @pass-25-solutions;
   }
 .eoc {
-    &.formula-review-container {
+  &.formula-review-container {
     .metadata("Formula Review");
-    &::before {
-      container: h1;
-      pass: @pass-30-title;
-      data-type: document-title;
-      content: "Formula Review";
-    }
+    .doc-title("Formula Review");
   }
   &.practice-container {
     .metadata("Practice");
-    &::before {
-      container: h1;
-      pass: @pass-30-title;
-      data-type: document-title;
-      content: "Practice";
-   }
+    .doc-title("Practice");
   }
   &.free-response-container {
     .metadata("Homework");
-    &::before {
-      container: h1;
-      pass: @pass-30-title;
-      data-type: document-title;
-      content: "Homework";
-    }
+    .doc-title("Homework");
   }
   &.bring-together-exercises-container {
     .metadata("Bringing It Together: Practice");
-    &::before {
-      container: h1;
-      pass: @pass-30-title;
-      data-type: document-title;
-      content: "Bringing It Together: Practice";
-    }
+    .doc-title("Bringing It Together: Practice");
   }
-    &.bring-together-homework-container {
-      .metadata("Bringing It Together Homework");
-      &::before {
-      container: h1;
-      pass: @pass-30-title;
-      data-type: document-title;
-      content: "Bringing It Together: Homework";
-    }
-
+  &.bring-together-homework-container {
+    .metadata("Bringing It Together: Homework");
+    .doc-title("Bringing It Together: Homework");
   }
   &.references-container {
     .metadata("References");
-    &::before {
-      container: h1;
-      pass: @pass-30-title;
-      data-type: document-title;
-      content: "References";
-    }
+    .doc-title("References");
   }
   &.solutions-container {
     .metadata("Solutions");
-    &::before {
-      container: h1;
-      pass: @pass-30-title;
-      data-type: document-title;
-      content: "Solutions";
-    }
+    .doc-title("Solutions");
   }
 }
   // &::after {

--- a/books/styles/cooked.css
+++ b/books/styles/cooked.css
@@ -1,7 +1,7 @@
 /* http://meyerweb.com/eric/tools/css/reset/
-  v2.0b1 | 201101
-   NOTE: WORK IN PROGRESS
-   USE WITH CAUTION AND TEST WITH ABANDON */
+v2.0b1 | 201101
+NOTE: WORK IN PROGRESS
+USE WITH CAUTION AND TEST WITH ABANDON */
 html,
 body,
 div,
@@ -118,7 +118,7 @@ q:after {
 }
 /* remember to define visible focus styles!
 :focus {
-  outline: ?????;
+outline: ?????;
 } */
 /* remember to highlight inserts somehow! */
 ins {
@@ -184,13 +184,31 @@ body > [data-type="page"] [data-type="title"] {
   color: #0061AA;
   font-size: 1.5em;
 }
-[data-type="document-title"] {
+h1[data-type="document-title"] {
   font-size: 3em;
   margin-bottom: 1em;
   color: #0061AA;
+  text-align: left;
+  font-weight: bold;
+  line-height: normal;
+}
+div[data-type="document-title"] {
+  font-size: 3em;
+  margin-bottom: 1em;
+  color: #0061AA;
+  line-height: normal;
 }
 [data-type='chapter'] {
   margin-bottom: 3em;
+}
+[data-type='chapter'] > h1[data-type="document-title"] {
+  font-size: 4em;
+  margin-bottom: 1em;
+  color: #0061AA;
+  text-transform: uppercase;
+  text-align: left;
+  font-weight: bold;
+  line-height: normal;
 }
 [data-type='chapter'] [data-type='page'] {
   margin-bottom: 1em;
@@ -229,24 +247,16 @@ body > [data-type="page"] [data-type="title"] {
   padding: 10px;
   border: solid 1px black;
 }
-[data-type="glossary"] [data-type='glossary-title'] {
-  border-bottom: 1px solid #FAA61A;
-  font-size: 16px;
-  color: #0061AA;
-  margin-bottom: 0.5em;
-  line-height: 1.5em;
-  font-weight: bold;
-}
-.eoc-glossary dl {
+.eoc.glossary dl {
   margin-bottom: 0.5em;
 }
-.eoc-glossary dl dt {
+.eoc.glossary dl dt {
   font-weight: bold;
   padding-right: ;
   display: inline;
 }
-.eoc-glossary dl dt,
-.eoc-glossary dl dd {
+.eoc.glossary dl dt,
+.eoc.glossary dl dd {
   display: inline;
 }
 div[class^="eoc-"] h1 {

--- a/books/styles/cooked.less
+++ b/books/styles/cooked.less
@@ -1,9 +1,9 @@
 
 
 /* http://meyerweb.com/eric/tools/css/reset/
-  v2.0b1 | 201101
-   NOTE: WORK IN PROGRESS
-   USE WITH CAUTION AND TEST WITH ABANDON */
+v2.0b1 | 201101
+NOTE: WORK IN PROGRESS
+USE WITH CAUTION AND TEST WITH ABANDON */
 
 html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
@@ -45,7 +45,7 @@ q:before, q:after {
 
 /* remember to define visible focus styles!
 :focus {
-  outline: ?????;
+outline: ?????;
 } */
 
 /* remember to highlight inserts somehow! */
@@ -113,16 +113,33 @@ body > [data-type="page"] {
     font-size: 1.5em;
   }
 }
-[data-type="document-title"] {
+h1[data-type="document-title"] {
   font-size: 3em;
   margin-bottom: 1em;
   color: @blue;
+  text-align: left;
+  font-weight: bold;
+  line-height: normal;
+}
+div[data-type="document-title"] {
+  font-size: 3em;
+  margin-bottom: 1em;
+  color: @blue;
+  line-height: normal;
 }
 [data-type='chapter'] {
   margin-bottom: 3em;
   section.key-equations {
-
-}
+  }
+  > h1[data-type="document-title"] {
+    font-size: 4em;
+    margin-bottom: 1em;
+    color: @blue;
+    text-transform: uppercase;
+    text-align: left;
+    font-weight: bold;
+    line-height: normal;
+  }
   [data-type='page'] {
     margin-bottom: 1em;
     figcaption {
@@ -157,50 +174,45 @@ body > [data-type="page"] {
         border: solid 1px black;
       }
     }
-  tbody td {
+    tbody td {
       padding: 10px;
       border: solid 1px black;
     }
     margin: auto;
   }
 }
-  [data-type="glossary"] {
-      [data-type='glossary-title'] {
-        .title;
-      }
+.eoc.glossary {
+  dl {
+    margin-bottom: @spacing;
+    dt {
+      font-weight: bold;
+      padding-right: ;
+      display: inline;
+    }
+    dt, dd {
+      display: inline;
+    }
   }
-    .eoc-glossary {
-      dl {
-        margin-bottom: @spacing;
-        dt {
-          font-weight: bold;
-          padding-right: ;
-          display: inline;
-        }
-        dt, dd {
-          display: inline;
-        }
-      }
+}
+div[class^="eoc-"] {
+  h1 {
+    margin-bottom: @spacing;
+    .title;
+  }
+  [data-type="document-title"] {
+    font-weight: bold;
+    padding-top: .5em;
+    font-size: 1.2em;
+    color: @blue;
+  }
+}
+.eoc-summary {
+  .summary {
+    h1 {
+      display: none;
     }
-    div[class^="eoc-"] {
-      h1 {
-        margin-bottom: @spacing;
-        .title;
-      }
-      [data-type="document-title"] {
-          font-weight: bold;
-          padding-top: .5em;
-          font-size: 1.2em;
-          color: @blue;
-        }
-    }
-    .eoc-summary {
-      .summary {
-        h1 {
-          display: none;
-        }
-      }
-    }
+  }
+}
 [data-type="abstract"] {
   border: solid 1px @blue;
   margin-bottom: @spacing;
@@ -221,7 +233,7 @@ body > [data-type="page"] {
   > h1 {
     .title();
   }
-  }
+}
 [data-type="example"] {
   background: fade(@blue , 10%);
   padding: 1em;
@@ -243,7 +255,7 @@ body > [data-type="page"] {
   padding: 1em;
   margin-bottom: 1em;
   [data-type="title"]{
-  .title();
+    .title();
   }
   span[data-type="title"]{
     display: block;
@@ -258,8 +270,8 @@ body > [data-type="page"] {
 
 div[class^="eob-"]  {
   h1 {
-   font-size: 2em;
-   color: @blue;
+    font-size: 2em;
+    color: @blue;
   }
 }
 span[data-type="term"] {


### PR DESCRIPTION
All document-title elements are now containers for spans containing title information including numbering. Each part of the numbering and title is contained in its own span. In addition, document-title containers are all changed to div elements except for chapter document-titles which remain h1. Titles in the TOC are now unwrapped, so that the <a> elements only contain the same series of spans.